### PR TITLE
Fix workflow checkout and increase diff limit

### DIFF
--- a/.github/workflows/fix_agent.yml
+++ b/.github/workflows/fix_agent.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/review_agent.yml
+++ b/.github/workflows/review_agent.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/review_agent.py
+++ b/review_agent.py
@@ -320,7 +320,7 @@ class PRReviewer:
             files = self.get_changed_files(pr)
 
             # Truncate massive diffs to avoid blowing context
-            MAX_DIFF_CHARS = 50000
+            MAX_DIFF_CHARS = 100000
             original_len = len(diff)
             if original_len > MAX_DIFF_CHARS:
                 diff = diff[:MAX_DIFF_CHARS] + f"\n\n... [TRUNCATED — {original_len} chars total, showing first {MAX_DIFF_CHARS}]"


### PR DESCRIPTION
## Summary
- Pin `review_agent` and `fix_agent` workflows to always checkout `main` instead of the PR merge commit — prevents `ImportError` when a PR branch has an older `llm_client.py` without `ModelRouter`
- Increase `MAX_DIFF_CHARS` from 50k to 100k so large PRs aren't reviewed with a truncated diff

## Test plan
- [ ] Trigger Review PRs workflow on PR #36 and confirm no `ImportError`
- [ ] Confirm fix agent triggers cleanly after a Foreman review

🤖 Generated with [Claude Code](https://claude.com/claude-code)