### PR TITLE
Mandate Pytest stubs in issue refinement process

### DIFF
--- a/seed_agent.py
+++ b/seed_agent.py
@@ -252,6 +252,21 @@ Break the work into concrete subtasks:
 - [ ] Subtask 2
 (minimum 2 subtasks)
 
+## Tests
+Provide concrete definition-of-done via pytest stubs.
+Include at least two stubs: one happy path and one edge/failure case.
+Use Given/When/Then comments inside the stubs.
+Generated tests must be designed to run with `pytest` using mocks/fixtures for external boundaries (GitHub API, LLMs).
+
+Example format:
+```python
+def test_example_happy_path():
+    # Given: [setup]
+    # When: [action]
+    # Then: [assertion]
+    pass
+```
+
 ## Complexity Estimate
 - T-shirt size: XS / S / M / L / XL
 - Estimated API cost: low / medium / high
@@ -260,6 +275,7 @@ Rules:
 - Keep the original intent but make it precise and actionable
 - If the original is vague, make reasonable assumptions and state them
 - Title should be imperative: "Add X", "Fix Y", "Implement Z"
+- Every refined issue MUST include a non-empty `## Tests` section with at least two pytest stubs.
 - Be concise. No filler. Every word earns its place.
 """
 
@@ -398,6 +414,12 @@ class ForemanAgent:
                 return False
 
             refined_body = response.text
+
+            # Validation for mandatory tests section
+            if "## Tests" not in refined_body or refined_body.count("def test_") < 2:
+                log.error(f"  ❌ Refinement for #{issue.number} failed validation: missing mandatory '## Tests' section or sufficient stubs.")
+                self.stats["failed"] += 1
+                return False
 
             # Extract a better title — route to title_gen (usually cheapest model)
             title_response = self._complete(


### PR DESCRIPTION
## Summary

Updates the seed agent to require and generate a '## Tests' section with pytest function stubs for all refined issues. Adds validation logic to prevent applying the 'auto-refined' label if the tests section is missing.

## Closes

Closes #55

## Files Changed

- `seed_agent.py` (modify): Update system prompt to require a '## Tests' section containing at least two pytest stubs (happy path and edge/failure case) structured with Given/When/Then comments. Modify the refinement validation logic to ensure the '## Tests' section is present and non-empty before applying the 'auto-refined' label.

## Acceptance Criteria

- [ ] Every issue refined by the seed agent must include a `

---
_Implemented by FOREMAN_