### PR TITLE
feat: mandate pytest stubs in seed agent issue refinement

### DIFF
--- a/seed_agent.py
+++ b/seed_agent.py
@@ -50,10 +50,11 @@ LABEL_REFINED_OUT = "refined-out"  # closed originals that spawned a refined ver
 LABEL_DRAFT = "draft"
 LABEL_READY = "ready"  # refined and ready for implementation
 LABEL_HOLD = "hold"    # pause auto-promotion
+LABEL_REFINEMENT_FAILED = "refinement-failed"
 
 # Safety: labels we NEVER process through the refine pipeline
 LABEL_IMPLEMENTING = "foreman-implementing"
-FORBIDDEN_LABELS = {LABEL_AUTO_REFINED, LABEL_REFINED_OUT, LABEL_DRAFT, LABEL_READY, LABEL_IMPLEMENTING, LABEL_HOLD}
+FORBIDDEN_LABELS = {LABEL_AUTO_REFINED, LABEL_REFINED_OUT, LABEL_DRAFT, LABEL_READY, LABEL_IMPLEMENTING, LABEL_HOLD, LABEL_REFINEMENT_FAILED}
 
 # ─── Logging ──────────────────────────────────────────────────
 
@@ -108,6 +109,7 @@ class GitHubClient:
                 LABEL_DRAFT: "c5def5",              # light blue
                 LABEL_READY: "0075ca",              # blue — ready for implementation
                 LABEL_HOLD: "d93f0b",               # orange
+                LABEL_REFINEMENT_FAILED: "e11d21",  # bright red
             }
             for name, color in label_configs.items():
                 if name not in existing:
@@ -414,8 +416,16 @@ class ForemanAgent:
             refined_body = response.text
 
             # Validation: Ensure ## Tests section and at least 2 pytest stubs
-            if "## Tests" not in refined_body or refined_body.count("def test_") < 2:
+            if "## tests" not in refined_body.lower() or refined_body.count("def test_") < 2:
                 log.warning(f"  ⚠️ Refinement of #{issue.number} failed validation: missing or insufficient ## Tests section")
+                try:
+                    if not self.dry_run:
+                        issue.create_comment("⚠️ **FOREMAN Auto-Refinement Failed**\nThe LLM failed to generate the required `## Tests` section with at least 2 pytest stubs. Human intervention required.")
+                        issue.add_to_labels(LABEL_REFINEMENT_FAILED)
+                    else:
+                        log.info(f"  [DRY RUN] Would comment and label #{issue.number} as {LABEL_REFINEMENT_FAILED}")
+                except Exception as e:
+                    log.warning(f"Could not comment or label issue #{issue.number}: {e}")
                 self.stats["failed"] += 1
                 return False
 


### PR DESCRIPTION
## Summary

Updates the seed agent's system prompt to require a `## Tests` section containing pytest function stubs structured with Given/When/Then comments. Modifies the refinement pipeline to validate the presence of this section before applying the `auto-refined` label.

## Closes

Closes #55

## Files Changed

- `seed_agent.py` (modify): Update the system prompt to mandate a `## Tests` section with at least two pytest stubs (happy path and edge/failure case) using Given/When/Then comments and mocks/fixtures. Add validation logic before labeling the issue `auto-refined` to verify the presence of the `## Tests` section and specific test stubs.

## Acceptance Criteria

- [ ] Every issue refined by the seed agent must include a `

---
_Implemented by FOREMAN_