### PR TITLE
Fix council chair JSON parsing error for malformed LLM output

### DIFF
--- a/brain/council.py
+++ b/brain/council.py
@@ -347,9 +347,24 @@ def extract_json(text: str) -> str:
     return stripped
 
 
+def _fix_json(text: str) -> str:
+    """Fix common JSON issues produced by LLMs (trailing commas, Python literals)."""
+    # Remove trailing commas before closing brackets/braces
+    text = re.sub(r",\s*([}\]])", r"\1", text)
+    # Replace Python-style literals with JSON equivalents (outside strings is best-effort)
+    text = re.sub(r"\bTrue\b", "true", text)
+    text = re.sub(r"\bFalse\b", "false", text)
+    text = re.sub(r"\bNone\b", "null", text)
+    return text
+
+
 def parse_json_response(text: str) -> dict:
     """Extract and parse JSON from an LLM response."""
-    return json.loads(extract_json(text))
+    extracted = extract_json(text)
+    try:
+        return json.loads(extracted)
+    except json.JSONDecodeError:
+        return json.loads(_fix_json(extracted))
 
 
 def parse_agent_response(text: str) -> AgentResponse:

--- a/tests/brain/test_council.py
+++ b/tests/brain/test_council.py
@@ -121,6 +121,36 @@ class TestParseJsonResponse:
         with pytest.raises(json.JSONDecodeError):
             parse_json_response("not json at all")
 
+    def test_trailing_comma_in_object(self) -> None:
+        from brain.council import parse_json_response
+        text = '{"decision": "build", "action_plan": "step 1",}'
+        result = parse_json_response(text)
+        assert result["decision"] == "build"
+
+    def test_trailing_comma_in_assignments(self) -> None:
+        from brain.council import parse_json_response
+        text = '{"assignments": {"gandalf": "task A", "gimli": "task B",}}'
+        result = parse_json_response(text)
+        assert result["assignments"]["gandalf"] == "task A"
+
+    def test_python_boolean_true(self) -> None:
+        from brain.council import parse_json_response
+        text = '{"flag_for_jord": True, "flag_reason": "risky"}'
+        result = parse_json_response(text)
+        assert result["flag_for_jord"] is True
+
+    def test_python_boolean_false(self) -> None:
+        from brain.council import parse_json_response
+        text = '{"flag_for_jord": False, "flag_reason": ""}'
+        result = parse_json_response(text)
+        assert result["flag_for_jord"] is False
+
+    def test_python_none(self) -> None:
+        from brain.council import parse_json_response
+        text = '{"decision": "build", "flag_reason": None}'
+        result = parse_json_response(text)
+        assert result["flag_reason"] is None
+
 
 class TestPydanticValidation:
     def testparse_agent_response(self) -> None:


### PR DESCRIPTION
Add _fix_json() helper that recovers from common LLM JSON issues:
- Trailing commas before } or ] (most likely cause of the reported error)
- Python-style True/False/None instead of JSON true/false/null

parse_json_response() now tries strict json.loads() first and falls
back to the fixed version only on JSONDecodeError, so valid JSON is
unaffected.

Also adds test coverage for all three recovery cases.

https://claude.ai/code/session_01HfxUNZYC3AeHF9iCfzhFBs